### PR TITLE
[imp] allow ignoring buffers with regex

### DIFF
--- a/README.org
+++ b/README.org
@@ -268,6 +268,12 @@ Several options are available through Emacs' Customize interface under
 
   Default: '(" *which-key*")
 
+- =winum-ignored-buffers-regex=
+
+  List of regexes. Matching buffers will be ignored when assigning numbers.
+
+  Default: '()
+
 - face: =winum-face=
 
   Face used for the number in the mode-line.

--- a/winum.el
+++ b/winum.el
@@ -155,6 +155,12 @@ result of `winum-get-number-string'."
   :group 'winum
   :type  '(repeat string))
 
+(defcustom winum-ignored-buffers-regex '()
+  "List of regex for buffers to ignore when assigning numbers."
+  :group 'winum
+  :type '(repeat string)
+  :risky t)
+
 (defface winum-face '()
   "Face used for the number in the mode-line."
   :group 'winum)
@@ -538,7 +544,10 @@ windows, however a higher number can be reserved by the user-defined
     (or (not (and (frame-live-p f)
                   (frame-visible-p f)))
         (string= "initial_terminal" (terminal-name f))
-        (member (buffer-name (window-buffer window)) winum-ignored-buffers))))
+        (member (buffer-name (window-buffer window)) winum-ignored-buffers)
+        (cl-some
+         (lambda (regex) (string-match regex (buffer-name (window-buffer window))))
+         winum-ignored-buffers-regex))))
 
 (defun winum--list-windows-in-frame (&optional f)
   "List windows in frame F using natural Emacs ordering."


### PR DESCRIPTION
Implements https://github.com/deb0ch/emacs-winum/issues/11
As it is long time forgotten but a very good feature required by, as an example,
https://github.com/Alexander-Miller/treemacs
https://github.com/emacs-lsp/lsp-ui