### PR TITLE
Bump version to 2.3.0 for NonGNU ELPA

### DIFF
--- a/winum.el
+++ b/winum.el
@@ -17,7 +17,7 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ;;
 ;; Author: Thomas de Beauchêne <thomas.de.beauchene@gmail.com>
-;; Version: 2.2.0
+;; Version: 2.3.0
 ;; Keywords: convenience, frames, windows, multi-screen
 ;; URL: http://github.com/deb0ch/winum.el
 ;; Created: 2016


### PR DESCRIPTION
Hi!

I am investigating if we could add this package to [NonGNU ELPA](http://elpa.nongnu.org/) (see link), a new Emacs Lisp package archive that will be enabled by default in Emacs 28. This means that users of that version or later will be able to install this package without any configuration: they can just run `M-x list-packages` and install it out of the box. We hope that this will improve Emacs and help bring new users to this package and others.

The main difference between NonGNU ELPA and MELPA is that only stable versions of packages are released. A new release will be made automatically when you bump the ";; Version: NNN" commentary header in this repository, as I do in this commit. NonGNU ELPA does not look at any "git tag". In the future, you can bump the package version in that header (thereby releasing a new version) when you think it makes sense and at your convenience.

The rules for accepting a package into NonGNU ELPA are here, for your reference:
https://git.savannah.gnu.org/cgit/emacs/nongnu.git/tree/README.org#n133

As far as I can tell, this package already follows the rules so there should be nothing more to do with regards to that. However, it would be good if you could review them and let us know if you think there will be any problems with following any of them going forward. Most rules are very straightforward and easy to follow, but note in particular that NonGNU ELPA does not distribute any package that recommends proprietary software.

Please let me know if you have any questions about NonGNU ELPA.

Thanks!

PS. If you could consider merging the other pull requests I've opened before this one, that would be ideal of course.